### PR TITLE
Fix invalid timestamp default values for MySQL 5.7

### DIFF
--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -34,8 +34,8 @@ module.exports = async cb => {
     size text,
     url text,
     provider text,
-    updated_at ${Model.client === 'pg' ? 'timestamp with time zone' : 'timestamp'},
-    created_at ${Model.client === 'pg' ? 'timestamp with time zone' : 'timestamp'}
+    updated_at ${Model.client === 'pg' ? 'timestamp with time zone' : 'timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'},
+    created_at ${Model.client === 'pg' ? 'timestamp with time zone' : 'timestamp DEFAULT CURRENT_TIMESTAMP'}
   );
 
   CREATE TABLE ${quote}upload_file_morph${quote} (

--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -460,8 +460,8 @@ CREATE TABLE ${quote}${details[currentModel].tableName}${quote} (
   role ${details[currentModel].client === 'pg' ? 'integer' : 'int'},
   ${quote}resetPasswordToken${quote} text,
   password text,
-  updated_at ${details[currentModel].client === 'pg' ? 'timestamp with time zone' : 'timestamp'},
-  created_at ${details[currentModel].client === 'pg' ? 'timestamp with time zone' : 'timestamp'}
+  updated_at ${details[currentModel].client === 'pg' ? 'timestamp with time zone' : 'timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'},
+  created_at ${details[currentModel].client === 'pg' ? 'timestamp with time zone' : 'timestamp DEFAULT CURRENT_TIMESTAMP'}
 );`);
             break;
           case 'role':


### PR DESCRIPTION
MySQL 5.7 is more strict than previous versions for dates as it requires a default value.

While installing contentajs with MySQL I had to manually run a few SQL queries. Some of them failed with the following error:

```
sql> CREATE TABLE `upload_file` (
  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
  name text,
  hash text,
  ext text,
  mime text,
  size text,
  url text,
  provider text,
  updated_at timestamp,
  created_at timestamp
)
[2018-04-18 08:14:09] [42000][1067] Invalid default value for 'created_at'
```

I had to adjust these timestamp fields so they define default values. After doing so I was able to run `strapi start` and view the homepage in the browser.

See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_in_date for details.